### PR TITLE
Patch for issue#6

### DIFF
--- a/src/main/java/com/fiestacabin/dropwizard/guice/AutoConfigService.java
+++ b/src/main/java/com/fiestacabin/dropwizard/guice/AutoConfigService.java
@@ -9,6 +9,9 @@ import com.yammer.dropwizard.lifecycle.Managed;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 
 import com.google.inject.Injector;
 import com.sun.jersey.spi.inject.InjectableProvider;
@@ -30,10 +33,19 @@ public abstract class AutoConfigService<T extends Configuration> extends GuiceSe
 	
 	private Reflections reflections;
     
-	protected AutoConfigService(String name, String basePackage) {
+	protected AutoConfigService(String name, String ... basePackages) {
 		super(name);
-		this.reflections = new Reflections(basePackage, 
-				new SubTypesScanner(), new TypeAnnotationsScanner());
+
+		ConfigurationBuilder cfgBldr = new ConfigurationBuilder();
+    FilterBuilder filterBuilder = new FilterBuilder();
+    for(String basePkg : basePackages){
+      cfgBldr.addUrls( ClasspathHelper.forPackage(basePkg) );
+      filterBuilder.include( FilterBuilder.prefix(basePkg) );
+    }
+      
+    cfgBldr.filterInputsBy(filterBuilder)
+           .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner());
+    this.reflections = new Reflections(cfgBldr);
 	}
 
     protected AutoConfigService(String basePackage) {

--- a/src/test/java/com/fiestacabin/dropwizard/common/resources/CommonResource.java
+++ b/src/test/java/com/fiestacabin/dropwizard/common/resources/CommonResource.java
@@ -1,0 +1,30 @@
+package com.fiestacabin.dropwizard.common.resources;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import com.fiestacabin.dropwizard.guice.test.service.MyService;
+
+@Path("common-resource")
+public class CommonResource {
+
+	private MyService myService;
+	
+	@Inject
+	public CommonResource(MyService myService) {
+		this.myService = myService;
+	}
+	
+	@GET
+	public Response doGet(){
+		return Response.ok("We have so much in common!!!").build();
+	}
+	
+	public MyService getMyService() {
+		return myService;
+	}
+	
+}
+

--- a/src/test/java/com/fiestacabin/dropwizard/guice/AutoConfigServiceTest.java
+++ b/src/test/java/com/fiestacabin/dropwizard/guice/AutoConfigServiceTest.java
@@ -4,7 +4,16 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -12,6 +21,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.fiestacabin.dropwizard.common.resources.CommonResource;
+import com.fiestacabin.dropwizard.guice.test.MultiPackageService;
 import com.fiestacabin.dropwizard.guice.test.SampleService;
 import com.fiestacabin.dropwizard.guice.test.SampleServiceConfiguration;
 import com.fiestacabin.dropwizard.guice.test.health.MyHealthCheck;
@@ -40,6 +51,28 @@ public class AutoConfigServiceTest {
 		ArgumentCaptor<MyResource> resource = ArgumentCaptor.forClass(MyResource.class);
 		verify(environment).addResource(resource.capture());
 		assertThat(resource.getValue(), is(MyResource.class));
+	}
+	
+	@Test
+	public void itInstallsMultiPackageResources() throws Exception {
+		MultiPackageService s = new MultiPackageService();
+		s.initializeWithBundles(configuration, environment);
+		
+		ArgumentCaptor<?> captor = ArgumentCaptor.forClass(Object.class);
+		verify(environment, times(2)).addResource(captor.capture());
+		
+		List<?> values = captor.getAllValues();
+		assertEquals(2, values.size());
+		
+		Set<Class<?>> expectedResults = new HashSet<Class<?>>();
+	  expectedResults.add(MyResource.class);
+	  expectedResults.add(CommonResource.class);
+	  for(Object obj : values){
+	    Class<?> cls = obj.getClass();
+	    expectedResults.remove(cls);
+	  }
+	  
+	  assertTrue(expectedResults.isEmpty());
 	}
 	
 	@Test

--- a/src/test/java/com/fiestacabin/dropwizard/guice/test/MultiPackageService.java
+++ b/src/test/java/com/fiestacabin/dropwizard/guice/test/MultiPackageService.java
@@ -1,0 +1,30 @@
+package com.fiestacabin.dropwizard.guice.test;
+
+import com.fiestacabin.dropwizard.guice.AutoConfigService;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.yammer.dropwizard.config.Environment;
+
+/**
+ * A test service that uses the varargs constructor for AutoConfigService
+ * @author ggavares
+ *
+ */
+public class MultiPackageService extends AutoConfigService<SampleServiceConfiguration> {
+  
+  public MultiPackageService() {
+    super("sample-service", "com.fiestacabin.dropwizard.guice.test", "com.fiestacabin.dropwizard.common.resources");
+  }
+  
+  @Override
+  protected Injector createInjector(SampleServiceConfiguration configuration) {
+    return Guice.createInjector(new SampleServiceModule());
+  }
+  
+  @Override
+  protected void initializeWithInjector(
+      SampleServiceConfiguration configuration, Environment environment,
+      Injector injector) throws Exception {
+    super.initializeWithInjector(configuration, environment, injector);
+  }
+}


### PR DESCRIPTION
Add ability to pass multiple base packages to constructor for
AutoConfigService.

Added unit test to AutoConfigServiceTest to verify that multiple package
paths are scanned and that all resources are loaded.

Patch for Issue #6
